### PR TITLE
Append &path to inc_path correctly

### DIFF
--- a/autoload/perl_local_lib_path.vim
+++ b/autoload/perl_local_lib_path.vim
@@ -56,7 +56,9 @@ function! perl_local_lib_path#add_perl_paths(perl_paths)
   let perl_lib_dirs = copy(s:perl_lib_dirs)
   call extend(perl_lib_dirs, a:perl_paths)
   let inc_paths = s:uniq(map(perl_lib_dirs, 'simplify(root_path . "/" . v:val)'))
-  let path_str = join(inc_paths, ',') . &path
+  let original_paths = split(&path, ',')
+  call extend(inc_paths, original_paths)
+  let path_str = join(inc_paths, ',')
   execute "set path=".path_str
 endfunction
 


### PR DESCRIPTION
`&path` が `.` のような値だったとき、単純に文字列結合しているため `&path` が期待された値にならない問題を修正しました。
